### PR TITLE
Gpt4o-mini 로 모델 교체 작업

### DIFF
--- a/mom/service.py
+++ b/mom/service.py
@@ -50,7 +50,7 @@ async def process_message(messages):
                 {"role": "system", "content": "You are a meeting summarization bot."},
                 {"role": "user", "content": prompt}
             ],
-            model="gpt-3.5-turbo",
+            model="gpt-4o",
         )
 
         response_message = chat_completion.choices[0].message.content.strip()

--- a/mom/service.py
+++ b/mom/service.py
@@ -64,7 +64,7 @@ async def process_message(messages):
 
 
 def split_message_into_chunks(messages, max_tokens):
-    enc = tiktoken.encoding_for_model("gpt-3.5-turbo")
+    enc = tiktoken.encoding_for_model("gpt-4o-mini")
     chunks = []
     current_chunk = []
     current_length = 0

--- a/mom/service.py
+++ b/mom/service.py
@@ -13,7 +13,7 @@ async def process_message(messages):
     cost = 0.0
 
     # 메시지를 토큰 수 제한 내에서 분할
-    chunks = split_message_into_chunks(messages, max_tokens=13000)
+    chunks = split_message_into_chunks(messages, max_tokens=100000)
 
     # GPT 모델에 요약 요청
     for chunk in chunks:

--- a/mom/service.py
+++ b/mom/service.py
@@ -19,7 +19,8 @@ async def process_message(messages):
     for chunk in chunks:
         prompt = f""" You are a meeting summarization bot. Your main task is to read the conversation, generate a 
         detailed meeting note body in html format in korean. Do not use any information from the example conversation 
-        in your output. Only use the information from the provided Conversation to summarize.:
+        in your output. Only use the information from the provided Conversation to summarize. do not include 
+        '```html` and '```' in your output.
     
         Example conversation:
         keyword(여행 계획): 여행 장소 및 관광지 회의 \n conversations: [speaker(준호): 우리 여행 가자. speaker(윤아): 
@@ -50,7 +51,7 @@ async def process_message(messages):
                 {"role": "system", "content": "You are a meeting summarization bot."},
                 {"role": "user", "content": prompt}
             ],
-            model="gpt-4o",
+            model="gpt-4o-mini",
         )
 
         response_message = chat_completion.choices[0].message.content.strip()

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -85,7 +85,7 @@ async def process_message(user_message):
         {{
           "main": {{
             "keyword": "점심 식사",
-            "subject": "점심 식사에 관한 회의",
+            "subject": "점심 식사에 관한 회의"
           }},
           "sub": [
             {{

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -16,7 +16,7 @@ async def process_message(user_message):
     prompt = f""" You are a meeting summarization bot. Your main task is to read the conversation, generate very 
     short titles as keywords (nouns), and summarize the content into key points under the corresponding topics. There 
     can be multiple main topics, and each main topic can have multiple subtopics with a vertex depth of up to 3 
-    levels. Make sure to include all sub-levels even if they are empty lists. this is important you must include least
+    levels. this is important you must include least
     two subtopics.
 
     Here is an example of a conversation and the desired output format:

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -144,8 +144,8 @@ async def process_message(user_message):
         model="gpt-4o",
     )
 
-    response_content = chat_completion.choices[0].message.content.strip()
-    print(f"GPT 응답: {chat_completion}")  # 응답 내용 출력
+    # response_content = chat_completion.choices[0].message.content.strip()
+    # print(f"GPT 응답: {chat_completion}")  # 응답 내용 출력
     response_message = json.loads(chat_completion.choices[0].message.content.strip())
 
     idea = response_message.get("idea", [])

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -146,7 +146,19 @@ async def process_message(user_message):
 
     response_content = chat_completion.choices[0].message.content.strip()
     print(f"GPT 응답: {response_content}")  # 응답 내용 출력
-    response_message = json.loads(chat_completion.choices[0].message.content.strip())
+
+    # 이중 JSON 파싱 처리
+    if response_content.startswith('```json'):
+        response_content = response_content[7:-3].strip()
+    elif "```" in response_content:
+        response_content = response_content.split("```")[1].strip()
+
+    try:
+        response_message = json.loads(response_content)
+    except json.JSONDecodeError as e:
+        print(f"JSON 디코딩 에러: {e}")
+        print(f"응답 내용 (디코딩 실패): {response_content}")
+        raise e
 
     idea = response_message.get("idea", [])
 

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -16,7 +16,7 @@ async def process_message(user_message):
     prompt = f""" You are a meeting summarization bot. Your main task is to read the conversation, generate very 
     short titles as keywords (nouns), and summarize the content into key points under the corresponding topics. There 
     can be multiple main topics, and each main topic can have multiple subtopics with a vertex depth of up to 3 
-    levels. this is important you must include least
+    levels. Make sure to include all sub-levels even if they are empty lists. this is important you must include least
     two subtopics.
 
     Here is an example of a conversation and the desired output format:
@@ -34,48 +34,48 @@ async def process_message(user_message):
           "sub": [
             {{
               "keyword": "장소에 대한 회의",
-              "subject": "부산 혹은 대전으로 여행"
+              "subject": "부산 혹은 대전으로 여행",
               "sub": [
                 {{
                   "keyword": "부산",
-                  "subject": "부산의 명소 및 관광지"
+                  "subject": "부산의 명소 및 관광지",
                   "sub": [
                     {{
                       "keyword": "해운대",
-                      "subject": "부산의 해운대"
+                      "subject": "부산의 해운대",
                       "sub": []
                     }},
                     {{
                       "keyword": "바다",
-                      "subject": "해운대에서 바다가 보고싶음"
+                      "subject": "해운대에서 바다가 보고싶음",
                       "sub": []
                     }},
                     {{
                       "keyword": "서핑",
-                      "subject": "해운대에서 서핑하고 싶음"
+                      "subject": "해운대에서 서핑하고 싶음",
                       "sub": []
                     }}
                   ]
                 }},
                 {{
                   "keyword": "대전",
-                  "subject": "대전의 명소 및 관광지"
+                  "subject": "대전의 명소 및 관광지",
                   "sub": []
                 }}
               ]
             }},
             {{
               "keyword": "대전의 관광지 결정",
-              "subject": "성심당과 식장산을 방문하기로 함"
+              "subject": "성심당과 식장산을 방문하기로 함",
               "sub": [
                 {{
                   "keyword": "성심당",
-                  "subject": "대전 성심당 빵집"
+                  "subject": "대전 성심당 빵집",
                   "sub": []
                 }},
                 {{
                   "keyword": "식장산",
-                  "subject": "대전 식장산 전망대"
+                  "subject": "대전 식장산 전망대",
                   "sub": []
                 }}
               ]
@@ -85,42 +85,42 @@ async def process_message(user_message):
         {{
           "main": {{
             "keyword": "점심 식사",
-            "subject": "점심 식사에 관한 회의"
+            "subject": "점심 식사에 관한 회의",
           }},
           "sub": [
             {{
               "keyword": "메뉴에 대한 고민",
-              "subject": "치킨, 피자, 국밥 등의 메뉴"
+              "subject": "치킨, 피자, 국밥 등의 메뉴",
               "sub": [
                 {{
                   "keyword": "치킨",
-                  "subject": "점심 메뉴 치킨"
+                  "subject": "점심 메뉴 치킨",
                   "sub": []
                 }},
                 {{
                   "keyword": "피자",
-                  "subject": "점심 메뉴 피자"
+                  "subject": "점심 메뉴 피자",
                   "sub": []
                 }},
                 {{
                   "keyword": "국밥",
-                  "subject": "점심 메뉴 국밥"
+                  "subject": "점심 메뉴 국밥",
                   "sub": []
                 }}
               ]
             }},
             {{
               "keyword": "점심 식사 결정",
-              "subject": "가까운 한우곰탕에서 먹기로 결정"
+              "subject": "가까운 한우곰탕에서 먹기로 결정",
               "sub": [
                 {{
                   "keyword": "한우곰탕",
-                  "subject": "한우곰탕 맛집 및 메뉴"
+                  "subject": "한우곰탕 맛집 및 메뉴",
                   "sub": []
                 }},
                 {{
                   "keyword": "식당 위치",
-                  "subject": "한우곰탕 식당의 위치 및 정보"
+                  "subject": "한우곰탕 식당의 위치 및 정보",
                   "sub": []
                 }}
               ]

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -141,7 +141,7 @@ async def process_message(user_message):
             {"role": "system", "content": "You are a meeting summarization bot."},
             {"role": "user", "content": prompt}
         ],
-        model="gpt-3.5-turbo",
+        model="gpt-4o",
     )
 
     response_message = json.loads(chat_completion.choices[0].message.content.strip())

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -146,7 +146,7 @@ async def process_message(user_message):
     )
 
     response_content = chat_completion.choices[0].message.content.strip()
-    print(f"GPT 응답: {response_content}")  # 응답 내용 출력
+    # print(f"GPT 응답: {response_content}")  # 응답 내용 출력
 
     # 이중 JSON 파싱 처리
     if response_content.startswith('```json'):

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -14,9 +14,9 @@ async def process_message(user_message):
     윤아: 식장산 야경이 유명하대. 식장산 가자."""
 
     prompt = f""" You are a meeting summarization bot. Your main task is to read the conversation, generate very 
-    short titles as keywords (nouns), and summarize the content into key points under the corresponding topics. There 
+    short titles as keywords as nouns, and summarize the content into key points under the corresponding topics. There 
     can be multiple main topics, and each main topic can have multiple subtopics with a vertex depth of up to 3 
-    levels. Make sure to include all sub-levels even if they are empty lists.
+    levels. Make sure to include all sub-levels even if they are empty lists. try to make least two subtopics.
 
     Here is an example of a conversation and the desired output format:
 

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -16,8 +16,7 @@ async def process_message(user_message):
     prompt = f""" You are a meeting summarization bot. Your main task is to read the conversation, generate very 
     short titles as keywords (nouns), and summarize the content into key points under the corresponding topics. There 
     can be multiple main topics, and each main topic can have multiple subtopics with a vertex depth of up to 3 
-    levels. Make sure to include all sub-levels even if they are empty lists. this is important you must include least
-    two subtopics.
+    levels. Make sure to include all sub-levels even if they are empty lists.
 
     Here is an example of a conversation and the desired output format:
 

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -145,7 +145,7 @@ async def process_message(user_message):
     )
 
     response_content = chat_completion.choices[0].message.content.strip()
-    print(f"GPT 응답: {response_content}")  # 응답 내용 출력
+    print(f"GPT 응답: {chat_completion}")  # 응답 내용 출력
     response_message = json.loads(chat_completion.choices[0].message.content.strip())
 
     idea = response_message.get("idea", [])

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -130,7 +130,8 @@ async def process_message(user_message):
       ]
     }}
 
-    Now, summarize the following conversation into the specified JSON format, ensuring each sub-level is included, even if they are empty lists:
+    Now, summarize the following conversation into the specified JSON format, ensuring each sub-level is included, 
+    even if they are empty lists. this is important Only return the JSON data. Do not include any other information:
 
     Conversation to summarize:
     "{user_message}"

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -144,6 +144,8 @@ async def process_message(user_message):
         model="gpt-4o",
     )
 
+    response_content = chat_completion.choices[0].message.content.strip()
+    print(f"GPT 응답: {response_content}")  # 응답 내용 출력
     response_message = json.loads(chat_completion.choices[0].message.content.strip())
 
     idea = response_message.get("idea", [])

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -144,8 +144,8 @@ async def process_message(user_message):
         model="gpt-4o",
     )
 
-    # response_content = chat_completion.choices[0].message.content.strip()
-    # print(f"GPT 응답: {chat_completion}")  # 응답 내용 출력
+    response_content = chat_completion.choices[0].message.content.strip()
+    print(f"GPT 응답: {response_content}")  # 응답 내용 출력
     response_message = json.loads(chat_completion.choices[0].message.content.strip())
 
     idea = response_message.get("idea", [])

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -34,48 +34,48 @@ async def process_message(user_message):
           "sub": [
             {{
               "keyword": "장소에 대한 회의",
-              "subject": "부산 혹은 대전으로 여행",
+              "subject": "부산 혹은 대전으로 여행"
               "sub": [
                 {{
                   "keyword": "부산",
-                  "subject": "부산의 명소 및 관광지",
+                  "subject": "부산의 명소 및 관광지"
                   "sub": [
                     {{
                       "keyword": "해운대",
-                      "subject": "부산의 해운대",
+                      "subject": "부산의 해운대"
                       "sub": []
                     }},
                     {{
                       "keyword": "바다",
-                      "subject": "해운대에서 바다가 보고싶음",
+                      "subject": "해운대에서 바다가 보고싶음"
                       "sub": []
                     }},
                     {{
                       "keyword": "서핑",
-                      "subject": "해운대에서 서핑하고 싶음",
+                      "subject": "해운대에서 서핑하고 싶음"
                       "sub": []
                     }}
                   ]
                 }},
                 {{
                   "keyword": "대전",
-                  "subject": "대전의 명소 및 관광지",
+                  "subject": "대전의 명소 및 관광지"
                   "sub": []
                 }}
               ]
             }},
             {{
               "keyword": "대전의 관광지 결정",
-              "subject": "성심당과 식장산을 방문하기로 함",
+              "subject": "성심당과 식장산을 방문하기로 함"
               "sub": [
                 {{
                   "keyword": "성심당",
-                  "subject": "대전 성심당 빵집",
+                  "subject": "대전 성심당 빵집"
                   "sub": []
                 }},
                 {{
                   "keyword": "식장산",
-                  "subject": "대전 식장산 전망대",
+                  "subject": "대전 식장산 전망대"
                   "sub": []
                 }}
               ]
@@ -90,37 +90,37 @@ async def process_message(user_message):
           "sub": [
             {{
               "keyword": "메뉴에 대한 고민",
-              "subject": "치킨, 피자, 국밥 등의 메뉴",
+              "subject": "치킨, 피자, 국밥 등의 메뉴"
               "sub": [
                 {{
                   "keyword": "치킨",
-                  "subject": "점심 메뉴 치킨",
+                  "subject": "점심 메뉴 치킨"
                   "sub": []
                 }},
                 {{
                   "keyword": "피자",
-                  "subject": "점심 메뉴 피자",
+                  "subject": "점심 메뉴 피자"
                   "sub": []
                 }},
                 {{
                   "keyword": "국밥",
-                  "subject": "점심 메뉴 국밥",
+                  "subject": "점심 메뉴 국밥"
                   "sub": []
                 }}
               ]
             }},
             {{
               "keyword": "점심 식사 결정",
-              "subject": "가까운 한우곰탕에서 먹기로 결정",
+              "subject": "가까운 한우곰탕에서 먹기로 결정"
               "sub": [
                 {{
                   "keyword": "한우곰탕",
-                  "subject": "한우곰탕 맛집 및 메뉴",
+                  "subject": "한우곰탕 맛집 및 메뉴"
                   "sub": []
                 }},
                 {{
                   "keyword": "식당 위치",
-                  "subject": "한우곰탕 식당의 위치 및 정보",
+                  "subject": "한우곰탕 식당의 위치 및 정보"
                   "sub": []
                 }}
               ]

--- a/nlp_keyword/service.py
+++ b/nlp_keyword/service.py
@@ -141,7 +141,7 @@ async def process_message(user_message):
             {"role": "system", "content": "You are a meeting summarization bot."},
             {"role": "user", "content": prompt}
         ],
-        model="gpt-4o",
+        model="gpt-4o-mini",
     )
 
     response_content = chat_completion.choices[0].message.content.strip()

--- a/util/cost_calculator.py
+++ b/util/cost_calculator.py
@@ -7,6 +7,9 @@ def calculate_cost(chat_completion):
     if model == "gpt-3.5-turbo-0125":
         prompt_cost_per_million = 0.05
         completion_cost_per_million = 1.50
+    elif model == "gpt-4o":
+        prompt_cost_per_million = 5
+        completion_cost_per_million = 15
     else:
         raise ValueError(f"Model not supported: {model}")
 

--- a/util/cost_calculator.py
+++ b/util/cost_calculator.py
@@ -10,6 +10,9 @@ def calculate_cost(chat_completion):
     elif model == "gpt-4o-2024-05-13":
         prompt_cost_per_million = 5
         completion_cost_per_million = 15
+    elif model == "gpt-4o-mini-2024-07-18":
+        prompt_cost_per_million = 0.15
+        completion_cost_per_million = 0.60
     else:
         raise ValueError(f"Model not supported: {model}")
 

--- a/util/cost_calculator.py
+++ b/util/cost_calculator.py
@@ -7,7 +7,7 @@ def calculate_cost(chat_completion):
     if model == "gpt-3.5-turbo-0125":
         prompt_cost_per_million = 0.05
         completion_cost_per_million = 1.50
-    elif model == "gpt-4o":
+    elif model == "gpt-4o-2024-05-13":
         prompt_cost_per_million = 5
         completion_cost_per_million = 15
     else:


### PR DESCRIPTION
openai를 사용하는 모든 모델을 gpt3.5-turbo 에서 gpt-4o-mini 로 교체 했습니다.

교체 이유
- 가격이 더 쌉니다.
- 성능이 더 좋습니다.
> openai 공식 문서에서 gpt 터보를 gpt4o미니로 교체하길 권고 했습니다. gpt3.5 터보보다 싸고 성능이 더 좋다고 합니다. 속도는 거의 똑같습니다.